### PR TITLE
Refactor the suggestion query to use a db for tracking dismissed suggestions

### DIFF
--- a/inc/ajax.php
+++ b/inc/ajax.php
@@ -123,9 +123,10 @@ function tdc_ajax_dismiss_consolidation_suggestions() {
 	check_ajax_referer('tdc_ajax_nonce', 'security');
 
 	$data = json_decode(stripslashes($_POST['request']), true);
+
 	$result = tdc_dismiss_suggestions_for_term($data['primary_term'], $data['taxonomy']);
 
-	if ($result) {
+	if ( ! is_wp_error($result) ) {
 		print json_encode(array(
 			'success' => true,
 			'message' => 'Dismissed!'

--- a/inc/pages.php
+++ b/inc/pages.php
@@ -6,10 +6,10 @@
  * @since 0.1
  */
 function tdc_suggestions_page() {
-	$taxonomy = 'post_tags';
+	$taxonomy = 'post_tag';
 	$dismissed = tdc_get_dismissed_suggestions( $taxonomy );
 
 	tdc_render_template( 'suggestions.php', array(
-		'existing' => empty( $dismissed )
+		'existing' => ! empty( $dismissed )
 	) );
 }

--- a/plugin.php
+++ b/plugin.php
@@ -9,6 +9,9 @@
  * License: GPLv2
  */
 
+/**
+ * Plugin set up
+ */
 function tdc_init() {
 	define('TDC_PLUGIN_FILE', __FILE__);
 	define('TDC_PLUGIN_DIR_URI', plugins_url(basename(__DIR__), __DIR__));
@@ -28,7 +31,28 @@ function tdc_init() {
 }
 add_action('init', 'tdc_init');
 
+/**
+ * On plugin activation, make sure the tdc_dismissed_suggestions table is created.
+ */
+function tdc_plugin_activate() {
+	global $wpdb;
 
+	$dismissed_suggestions_table = $wpdb->prefix . "tdc_dismissed_suggestions";
+
+	$result = $wpdb->query("
+		CREATE TABLE IF NOT EXISTS `" . $dismissed_suggestions_table . "` (
+			`id` int(11) NOT NULL AUTO_INCREMENT,
+			`term_id` bigint(20) unsigned NOT NULL,
+			`taxonomy` varchar(450) NOT NULL,
+			PRIMARY KEY (`id`),
+			UNIQUE KEY `term_id` (`term_id`)
+		) ENGINE=InnoDB;");
+}
+register_activation_hook( __FILE__, 'tdc_plugin_activate' );
+
+/**
+ * Add the TDC admin menu
+ */
 function tdc_admin_menu() {
 	add_menu_page(
 		'Term Debt Consolidator',


### PR DESCRIPTION
We've been storing dismissed terms as an array in the options table. When calling `get_terms` we'd pass the array of dismissed term IDs as the value for the `exclude` option which was working fine. However, when there are lots of dismissed terms/suggestions, the SQL statement generated by `get_terms` can become very long. Turns out this is bad for business.

So, this pull request includes:
- A plugin activation hook that adds a custom table for tracking dismissed suggestions
- A callback to the `get_terms` filter `list_terms_exclusions` to alter the SQL `NOT IN` clause to pull dismissed term IDs from the tracking table
- Refactor of the dismissed term helper functions to use the new db table
